### PR TITLE
feat: add it.each N support to repeat the test

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,25 @@ it.each(data)('element %s should %s', (selector, assertion) => {
 // "element .new-todo should not.be.visible"
 ```
 
+## Repeat the test N times
+
+You can use this module to simply repeat the test N times
+
+```js
+// repeat the same test 5 times
+it.each(5)('test %K of 5', function (k) {
+  // note the iteration index k is passed to each test
+  expect(k).to.be.within(0, 4)
+})
+
+// you can repeat the suite of tests
+describe.each(3)('suite %K of 3', function (k) {
+  ...
+})
+```
+
+See the [repeat-spec.js](./cypress/integration/repeat-spec.js)
+
 ## Test and suite titles
 
 You can use the arguments to the test callback in the test title in order.

--- a/cypress/integration/repeat-spec.js
+++ b/cypress/integration/repeat-spec.js
@@ -1,0 +1,16 @@
+// @ts-check
+/// <reference types="cypress" />
+
+import '../..'
+
+describe('Simply repeating the test N times', () => {
+  it.each(5)('test %K of 5', function (k) {
+    expect(k).to.be.within(0, 4)
+  })
+})
+
+describe.each(3)('suite %K of 3', function (k) {
+  it('works', () => {
+    expect(k).to.be.within(0, 2)
+  })
+})

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -11,14 +11,14 @@ declare namespace Mocha {
     /**
      * Iterates over each given item (optionally chunked), and creates
      * a separate test for each one.
-     * @param values Input items to create the tests form
+     * @param values Input items to create the tests form OR number of times to repeat a test
      * @param totalChunks (Optional) number of chunks to split the items into
      * @param chunkIndex (Optional) index of the chunk to get items from
      * @example it.each([1, 2, 3])('test %K', (x) => ...)
      * @see https://github.com/bahmutov/cypress-each
      */
     each<T = unknown>(
-      values: T[],
+      values: T[] | number,
       totalChunks?: number,
       chunkIndex?: number,
     ): (titlePattern: string | TestTitleFn<T>, fn: TestCallback<T>) => void
@@ -35,7 +35,7 @@ declare namespace Mocha {
      * @see https://github.com/bahmutov/cypress-each
      */
     each<T = unknown>(
-      values: T[],
+      values: T[] | number,
       totalChunks?: number,
       chunkIndex?: number,
     ): (titlePattern: string | TestTitleFn<T>, fn: TestCallback<T>) => void

--- a/src/index.js
+++ b/src/index.js
@@ -47,6 +47,14 @@ function makeTitle(titlePattern, value, k, values) {
 
 if (!it.each) {
   it.each = function (values, totalChunks, chunkIndex) {
+    if (typeof values === 'number') {
+      // the user wants to repeat the same test N times
+      if (values < 1) {
+        throw new Error('Number of test repetitions must be >= 1')
+      }
+      values = Cypress._.range(0, values)
+    }
+
     if (!Array.isArray(values)) {
       throw new Error('cypress-each: values must be an array')
     }
@@ -85,6 +93,14 @@ if (!it.each) {
 
 if (!describe.each) {
   describe.each = function (values) {
+    if (typeof values === 'number') {
+      // the user wants to repeat the same suite N times
+      if (values < 1) {
+        throw new Error('Number of suite repetitions must be >= 1')
+      }
+      values = Cypress._.range(0, values)
+    }
+
     if (!Array.isArray(values)) {
       throw new Error('cypress-each: values must be an array')
     }


### PR DESCRIPTION
You can use this module to simply repeat the test N times

```js
// repeat the same test 5 times
it.each(5)('test %K of 5', function (k) {
  // note the iteration index k is passed to each test
  expect(k).to.be.within(0, 4)
})

// you can repeat the suite of tests
describe.each(3)('suite %K of 3', function (k) {
  ...
})
```