### PR TITLE
Add support for %N test title

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,15 @@ it.each([10, 20, 30])('checking item %K', (x) => { ... })
 // "checking item 3"
 ```
 
+You can use `%N` to insert the total number of items
+
+```js
+it.each(['first', 'second'])('test %K of %N', (x) => { ... })
+// creates the tests
+// "test 1 of 2"
+// "test 2 of 2"
+```
+
 ### Title function
 
 You can form the test title yourself using a function. The function will get the item, the index, and all items and should return a string with the test title.

--- a/cypress/integration/format-spec.js
+++ b/cypress/integration/format-spec.js
@@ -4,7 +4,7 @@
 // @ts-ignore
 require('../..')
 // @ts-ignore
-const { formatTitle } = require('../../src/index.js')
+const { formatTitle, makeTitle } = require('../../src/index.js')
 
 describe('format', () => {
   const person = {
@@ -37,4 +37,18 @@ describe('format', () => {
       expect(life).to.equal(42)
     },
   )
+})
+
+describe('makeTitle', () => {
+  const values = [1, 2, 3]
+
+  it('makes title using %K', () => {
+    expect(makeTitle('one is %K', 1, 0, values)).to.equal('one is 1')
+  })
+
+  it('makes title using %k and value', () => {
+    expect(makeTitle('at index %k is value %d', 42, 0, values)).to.equal(
+      'at index 0 is value 42',
+    )
+  })
 })

--- a/cypress/integration/format-spec.js
+++ b/cypress/integration/format-spec.js
@@ -51,4 +51,10 @@ describe('makeTitle', () => {
       'at index 0 is value 42',
     )
   })
+
+  it('makes title using number of values', () => {
+    expect(makeTitle('value %d is %K of %N', 42, 0, values)).to.equal(
+      'value 42 is 1 of 3',
+    )
+  })
 })

--- a/src/index.js
+++ b/src/index.js
@@ -66,7 +66,6 @@ if (!it.each) {
       }
 
       values.forEach(function (value, k) {
-        // const testTitle = titlePattern.replace('%k', k).replace('%K', k + 1)
         const title = makeTitle(titlePattern, value, k, values)
         if (!title) {
           throw new Error(
@@ -113,7 +112,6 @@ if (!describe.each) {
     return function describeEach(titlePattern, testCallback) {
       // define a test for each value
       values.forEach((value, k) => {
-        // const testTitle = titlePattern.replace('%k', k).replace('%K', k + 1)
         const title = makeTitle(titlePattern, value, k, values)
 
         if (!title) {
@@ -134,4 +132,4 @@ if (!describe.each) {
   }
 }
 
-module.exports = { formatTitle, getChunk }
+module.exports = { formatTitle, makeTitle, getChunk }

--- a/src/index.js
+++ b/src/index.js
@@ -32,7 +32,10 @@ function getChunk(values, totalChunks, chunkIndex) {
 
 function makeTitle(titlePattern, value, k, values) {
   if (typeof titlePattern === 'string') {
-    const testTitle = titlePattern.replace('%k', k).replace('%K', k + 1)
+    const testTitle = titlePattern
+      .replace('%k', k)
+      .replace('%K', k + 1)
+      .replace('%N', values.length)
     if (Array.isArray(value)) {
       return formatTitle(testTitle, ...value)
     } else {


### PR DESCRIPTION
- closes #17 

You can use `%N` to insert the total number of items

```js
it.each(['first', 'second'])('test %K of %N', (x) => { ... })
// creates the tests
// "test 1 of 2"
// "test 2 of 2"
```